### PR TITLE
updates and new name

### DIFF
--- a/_data/clients/chats.yml
+++ b/_data/clients/chats.yml
@@ -1,0 +1,7 @@
+name: Chats (once Chatty)
+url: https://puri.sm/
+tracking_issue: "https://source.puri.sm/Librem5/chatty/issues?scope=all&utf8=%E2%9C%93&state=opened&search=omemo"     
+work_in_progress: yes   
+testing: yes        
+done: no   
+status: 50

--- a/_data/clients/chatty.yml
+++ b/_data/clients/chatty.yml
@@ -1,7 +1,0 @@
-name: Chatty (Purism's Librem One)
-url: https://puri.sm/
-tracking_issue: "https://puri.sm/posts/librem5-progress-report-19/"     
-work_in_progress: yes   
-testing: yes        
-done: no   
-status: 20


### PR DESCRIPTION
- purism renamed chatty to chats
  (https://puri.sm/posts/librem-5-october-2019-software-update/)
- better bugtracking url
- I didn't check but omemo seems to work according to bug tracker